### PR TITLE
Behalte aktuelle Seite bei Theme-Wechsel bei

### DIFF
--- a/src/main/java/de/justinharder/soq/view/theme/ThemeRessource.java
+++ b/src/main/java/de/justinharder/soq/view/theme/ThemeRessource.java
@@ -23,11 +23,8 @@ public class ThemeRessource implements Serializable
 	}
 
 	@POST
-	@Consumes
-	@Produces(MediaType.TEXT_HTML)
-	public TemplateInstance aendere()
+	public void aendere()
 	{
 		theme = theme.isDark() ? Theme.LIGHT : Theme.DARK;
-		return Templates.start(theme.getBezeichnung());
 	}
 }

--- a/src/main/resources/templates/header.html
+++ b/src/main/resources/templates/header.html
@@ -105,7 +105,7 @@
 
                     <li class="nav-item">
                         <form class="container-fluid justify-content-center"
-                              method="POST"
+                              method="POST" onsubmit="setTimeout(function(){ window.location.reload(); },100);"
                               action="/theme">
                             <button class="btn nav-link text-white py-2 px-0 px-lg-2 d-flex align-items-center"
                                     type="submit">


### PR DESCRIPTION
Moin,

mir ist aufgefallen, dass bei jedem Theme-Wechsel die Startseite aufgerufen wird.
Hier ist mein Vorschlag, wie man die aktuelle Seite beibehalten könnte. Das ist wahrscheinlich nicht die sauberste Lösung und eher als vorübergehender Vorschlag gedacht. 🦕

Beste Grüße,
Mattes